### PR TITLE
fix: schema not being generated as required

### DIFF
--- a/src/apispec_pydantic_plugin/resolver.py
+++ b/src/apispec_pydantic_plugin/resolver.py
@@ -90,7 +90,7 @@ class SchemaResolver:
         self, schema: dict[str, Any] | type[BaseModelAlias] | BaseModelAlias | str
     ) -> Any:
         if not isinstance(schema, dict):
-            resolved = resolve_schema_instance(schema=schema).schema
+            resolved = resolve_schema_instance(schema=schema).schema()
             return resolved
 
         if schema.get("type") == "array" and "items" in schema:


### PR DESCRIPTION
Example before:

```
"$ref": "#/components/schemas/<bound method BaseModel.schema of <class 'REDACTED.models.REDACTED.serializations.REDACTED.SerializedAnnouncement'>>"
```